### PR TITLE
DEV-729 Examples: Reconciliation between portfolios

### DIFF
--- a/lusid-sdk-csharp/LusidSdk.Tests/LusidApiTests.cs
+++ b/lusid-sdk-csharp/LusidSdk.Tests/LusidApiTests.cs
@@ -446,7 +446,7 @@ namespace LusidSdk.Tests
                 SettlementDate = tradeDate,
                 Units = quantity,
                 TradePrice = price,
-                TotalConsideration = 100 * price,
+                TotalConsideration = quantity * price,
                 Source = "Client"
             };
         }


### PR DESCRIPTION
This change introduces a new test/example of using the PerformReconciliation method.   It tests an inter day reconciliation on the same portfolio returns the correct beaks for the reconciliation time window.

2 other minor changes have been made to remove Resharper warnings of unused values from the tests.