### PR TITLE
DEV-742: Amending unit tests to use CreatePerpetualPropertyRequest when upserting portfolio trades.

### DIFF
--- a/lusid-sdk-csharp/LusidSdk.Tests/LusidApiTests.cs
+++ b/lusid-sdk-csharp/LusidSdk.Tests/LusidApiTests.cs
@@ -202,9 +202,9 @@ namespace LusidSdk.Tests
                 TradePrice = 12.3,
                 TotalConsideration = 1230,
                 Source = "Client",
-                Properties = new List<CreatePropertyRequest>
+                Properties = new List<CreatePerpetualPropertyRequest>
                 {
-                    new CreatePropertyRequest(propertyValue, scope, propertyName)
+                    new CreatePerpetualPropertyRequest(propertyValue, scope, propertyName)
                 }
             };
 


### PR DESCRIPTION
Trade properties are now perpetual and will assume the effective date of the trade to which they are attached.