### PR TITLE
aggregation modified - requires additional field. 

### DIFF
--- a/lusid-sdk-csharp/LusidSdk.Tests/LusidApiTests.cs
+++ b/lusid-sdk-csharp/LusidSdk.Tests/LusidApiTests.cs
@@ -421,6 +421,7 @@ namespace LusidSdk.Tests
                 RecipeId = new ResourceId(scope, "default"),
                 Metrics = new List<AggregateSpec>
                 {
+                    new AggregateSpec("Security/default/CommonName", "Value"),
                     new AggregateSpec("Holding/default/PV", "Proportion"),
                     new AggregateSpec("Holding/default/PV", "Sum")
                 },


### PR DESCRIPTION
The SDK changes as a result of work to make the requested aggregation behave more like a single table SQL statement. Previously behaviour translated a specification for something like "select A,B from results group by C" into "select A,B,C from results group by C". This now no longer happens silently.  