### PR TITLE
DEV-1731 Update tests and util methods to use ProblemDetails

### DIFF
--- a/sdk/Lusid.Sdk/Utilities/ApiExeceptionExtensions.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiExeceptionExtensions.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Lusid.Sdk.Client;
 using Lusid.Sdk.Model;
 using Newtonsoft.Json;
@@ -6,16 +7,50 @@ namespace Lusid.Sdk.Utilities
 {
     public static class ApiExeceptionExtensions
     {
-        public static ErrorResponse ErrorResponse(this ApiException ex)
+        /// <summary>
+        /// Identify whether the API exception was caused by a request validation problem
+        /// </summary>
+        public static bool IsValidationProblem(this ApiException ex)
+        {
+            return ex.ErrorCode == (int) HttpStatusCode.BadRequest;
+        }
+
+        /// <summary>
+        /// Try and get the details of a validation problem, if there are any
+        /// </summary>
+        public static bool TryGetValidationProblemDetails(this ApiException ex,
+            out LusidValidationProblemDetails details)
+        {
+            if (IsValidationProblem(ex))
+            {
+                details = ValidationProblemDetails(ex);
+                return true;
+            }
+
+            details = null;
+            return false;
+        }
+        
+        public static LusidValidationProblemDetails ValidationProblemDetails(this ApiException ex)
         {
             if (ex.ErrorContent == null)
             {
                 return null;
             }
             
-            //    ApiException.ErrorContent contains a JSON serialized ErrorResponse
-            ErrorResponse errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(ex.ErrorContent);
-            return errorResponse;
-        }        
+            //    ApiException.ErrorContent contains a JSON serialized ValidationProblemDetails
+            return JsonConvert.DeserializeObject<LusidValidationProblemDetails>(ex.ErrorContent);
+        }
+        
+        public static LusidProblemDetails ProblemDetails(this ApiException ex)
+        {
+            if (ex.ErrorContent == null)
+            {
+                return null;
+            }
+
+            //    ApiException.ErrorContent contains a JSON serialized ProblemDetails
+            return JsonConvert.DeserializeObject<LusidProblemDetails>(ex.ErrorContent);
+        }
     }
 }


### PR DESCRIPTION
In response to the development on the API side to comply with RFC-7807, replace those code features that used to use ErrorResponse with the standards compliant ProblemDetails and ValidationProblemDetails.

We've extended the base implementations to offer additional features, exposed as LusidProblemDetails and LusidValidationProiblemDetails.