### PR TITLE
DEV-3843 Improve error message when failing to get a token from idp

### DIFF
--- a/sdk/Lusid.Sdk/Utilities/ClientCredentialsFlowTokenProvider.cs
+++ b/sdk/Lusid.Sdk/Utilities/ClientCredentialsFlowTokenProvider.cs
@@ -118,7 +118,8 @@ namespace Lusid.Sdk.Utilities
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    throw new Exception("Failed to get a token: " + body);
+                    throw new HttpRequestException(
+                        $"Could not retrieve an authentication token from the specified identity provider. The request to {tokenRequest.RequestUri} returned an unsuccessful status code of {response.StatusCode} and the response body: {body}");
                 }
 
                 var parsed = JsonConvert.DeserializeObject<Dictionary<string, string>>(body);
@@ -177,7 +178,8 @@ namespace Lusid.Sdk.Utilities
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    throw new Exception("Failed to get a token: " + body);
+                    throw new HttpRequestException(
+                        $"Could not refresh the authentication token from the specified identity provider. The request to {tokenRequest.RequestUri} returned an unsuccessful status code of {response.StatusCode} and the response body: {body}");
                 }
 
                 var parsed = JsonConvert.DeserializeObject<Dictionary<string, string>>(body);


### PR DESCRIPTION
This small change makes the error returned when failing to get an auth/refresh token from the IDP include more information and be more user friendly.