### PR TITLE
DEV-7152: add finaliser to ApiClient to avoid socket leak

### DIFF
--- a/sdk/Lusid.Sdk/Utilities/ApiClient.Dispose.cs
+++ b/sdk/Lusid.Sdk/Utilities/ApiClient.Dispose.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+// ReSharper disable once CheckNamespace
+namespace Lusid.Sdk.Client
+{
+    // DEV-7152: Bug in .NET Core 2.2 means any un-disposed HttpClients will leak sockets
+    // https://github.com/dotnet/corefx/pull/38499
+    // https://github.com/dotnet/runtime/issues/29327
+    // Use a finalizer to ensure RestClient (and thus HttpClient) instances are always disposed
+
+    public partial class ApiClient : IDisposable
+    {
+        /// <summary />
+        public void Dispose()
+        {
+            DisposeImpl();
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary />
+        ~ApiClient()
+        {
+            DisposeImpl();
+        }
+
+        private void DisposeImpl()
+        {
+            RestClient?.Dispose();
+        }
+    }
+}

--- a/sdk/Lusid.Sdk/Utilities/LusidApiFactoryBuilder.cs
+++ b/sdk/Lusid.Sdk/Utilities/LusidApiFactoryBuilder.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Threading;
 using Microsoft.Extensions.Configuration;
 
 namespace Lusid.Sdk.Utilities
@@ -11,9 +9,6 @@ namespace Lusid.Sdk.Utilities
     /// </summary>
     public static class LusidApiFactoryBuilder
     {
-        private static readonly Dictionary<int, ILusidApiFactory> ThreadFactories = new Dictionary<int, ILusidApiFactory>();
-        private static readonly object Lock = new object();
-
         /// <summary>
         /// Create an ILusidApiFactory using the specified configuration file.  For details on the format of the configuration file see https://support.lusid.com/getting-started-with-apis-sdks
         /// </summary>
@@ -61,25 +56,15 @@ namespace Lusid.Sdk.Utilities
         /// </summary>
         public static ILusidApiFactory Build(string url, ITokenProvider tokenProvider)
         {
-            lock (Lock)
+            // TokenProviderConfiguration.ApiClient is the client used by LusidApiFactory and is 
+            // NOT thread-safe, so there needs to be a separate instance for each instance of LusidApiFactory.
+            // Do NOT cache the LusidApiFactory instances (DEV-6922)
+            var config = new TokenProviderConfiguration(tokenProvider)
             {
-                var threadId = Thread.CurrentThread.ManagedThreadId;
+                BasePath = url
+            };
 
-                if (!ThreadFactories.TryGetValue(threadId, out var factory))
-                {
-                    // TokenProviderConfiguration.ApiClient is the client used by LusidApiFactory and is 
-                    // not threadsafe, so there needs to be a separate instance for each instance of LusidApiFactory
-                    var config = new TokenProviderConfiguration(tokenProvider)
-                    {
-                        BasePath = url
-                    };
-
-                    factory = new LusidApiFactory(config);
-                    ThreadFactories[threadId] = factory;
-                }
-
-                return factory;
-            }
+            return new LusidApiFactory(config);
         }
     }
 }


### PR DESCRIPTION
Add workaround to prevent socket leakage when running on .NET Core 2.2

Also includes small performance improvement from Preview SDK