### PR TITLE
DEV-8462: Support multi-value properties

### DIFF
--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Properties.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Properties.cs
@@ -210,14 +210,14 @@ namespace Lusid.Sdk.Tests.tutorials.Ibor
                             propertyValue)
                 }
             );
-            Assert.That(propertiesUpsertResult.Properties.Values.Single().Value.LabelValueSet, Is.EqualTo(propertyValue.LabelValueSet));
+            Assert.That(propertiesUpsertResult.Properties.Values.Single().Value.LabelValueSet, Is.EqualTo(propertyValue.LabelValueSet).Using(LabelValueSetEquality));
 
             var portfolioProperties = _apiFactory.Api<IPortfoliosApi>().GetPortfolioProperties(TestDataUtilities.TutorialScope, portfolioResult.Id.Code).Properties;
 
             Assert.That(portfolioProperties.Keys, Is.EquivalentTo(new [] { propertyDefinitionResult.Key}));
 
             var returnedProperty = portfolioProperties[propertyDefinitionResult.Key];
-            Assert.That(returnedProperty.Value, Is.EqualTo(propertyValue).Using(Comparer));
+            Assert.That(returnedProperty.Value, Is.EqualTo(propertyValue).Using(PropertyEquality));
         }
     }
 }

--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Properties.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Properties.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Lusid.Sdk.Api;
+using Lusid.Sdk.Model;
+using Lusid.Sdk.Tests.Utilities;
+using Lusid.Sdk.Utilities;
+using static Lusid.Sdk.Utilities.PropertyExtensions;
+
+namespace Lusid.Sdk.Tests.tutorials.Ibor
+{
+    /// <summary>
+    /// Set up to create a ILusidApiFactory which is used to make calls to the
+    /// LUSID API.
+    /// </summary>
+    [TestFixture]
+    public class Properties
+    {
+        private ILusidApiFactory _apiFactory;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _apiFactory = LusidApiFactoryBuilder.Build("secrets.json");
+        }
+
+        [Test]
+        public void Create_Portfolio_With_Label_Property()
+        {
+            var uuid = Guid.NewGuid().ToString();
+            var labelPropertyName = $"fund-style-{uuid}";
+            var effectiveDate = new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            
+            //    Details of the property to be created
+            var labelPropertyDefinition = new CreatePropertyDefinitionRequest(
+                
+                //    The domain the property is to be applied to
+                domain: CreatePropertyDefinitionRequest.DomainEnum.Portfolio,
+                
+                //    The scope the property will be created in
+                scope: TestDataUtilities.TutorialScope,
+                
+                //    When the property value is set it will be valid forever and cannot be changed.
+                //    Properties whose values can change over time should be created with LifeTimeEnum.TIMEVARIANT
+                lifeTime: CreatePropertyDefinitionRequest.LifeTimeEnum.Perpetual,
+                
+                code: labelPropertyName,
+                valueRequired: false,
+                displayName: "Fund Style",
+                dataTypeId: new ResourceId("system", "string")
+            );
+
+            //    Create the property definition
+            var labelPropertyDefinitionResult = _apiFactory.Api<IPropertyDefinitionsApi>().CreatePropertyDefinition(labelPropertyDefinition);
+            
+            //    Create the property values
+            var labelPropertyValueRequest = new PropertyValue(labelValue: "Active");
+            
+            //    Details of the new portfolio to be created, created here with the minimum set of mandatory fields 
+            var createPortfolioRequest = new CreateTransactionPortfolioRequest(
+                code: $"id-{uuid}",
+                displayName: $"Portfolio-{uuid}",
+                baseCurrency: "GBP",
+                created: effectiveDate,
+                
+                //    Set the property value when creating the portfolio
+                properties: new Dictionary<string, Property>
+                {
+                    [labelPropertyDefinitionResult.Key] =
+                        new Property(
+                            labelPropertyDefinitionResult.Key,
+                            labelPropertyValueRequest)
+                }
+            );
+
+            //    Create the portfolio
+            var portfolioResult = _apiFactory.Api<ITransactionPortfoliosApi>().CreatePortfolio(TestDataUtilities.TutorialScope, createPortfolioRequest);
+            
+            Assert.That(portfolioResult.Id.Code, Is.EqualTo(createPortfolioRequest.Code));
+
+            var portfolioProperties = _apiFactory.Api<IPortfoliosApi>().GetPortfolioProperties(TestDataUtilities.TutorialScope, portfolioResult.Id.Code).Properties;
+
+            Assert.That(portfolioProperties.Keys, Is.EquivalentTo(new [] { labelPropertyDefinitionResult.Key }));
+
+            var labelProperty = portfolioProperties[labelPropertyDefinitionResult.Key];
+            Assert.That(labelProperty.Value.LabelValue, Is.EqualTo(labelPropertyValueRequest.LabelValue));
+        }
+
+        [Test]
+        public void Create_Portfolio_With_Metric_Property()
+        {
+            var uuid = Guid.NewGuid().ToString();
+            var metricPropertyName = $"fund-nav-{uuid}";
+            var effectiveDate = new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            
+            //    Details of the property to be created
+            var metricPropertyDefinition = new CreatePropertyDefinitionRequest(
+                
+                //    The domain the property is to be applied to
+                domain: CreatePropertyDefinitionRequest.DomainEnum.Portfolio,
+                
+                //    The scope the property will be created in
+                scope: TestDataUtilities.TutorialScope,
+                
+                //    When the property value is set it will be valid forever and cannot be changed.
+                //    Properties whose values can change over time should be created with LifeTimeEnum.TIMEVARIANT
+                lifeTime: CreatePropertyDefinitionRequest.LifeTimeEnum.Perpetual,
+                
+                code: metricPropertyName,
+                valueRequired: false,
+                displayName: "Fund NAV",
+                dataTypeId: new ResourceId("system", "currencyAndAmount")
+            );
+            
+            //    Create the property definitions
+            var metricPropertyDefinitionResult = _apiFactory.Api<IPropertyDefinitionsApi>().CreatePropertyDefinition(metricPropertyDefinition);
+            
+            //    Create the property values
+            var metricPropertyValueRequest = new PropertyValue(metricValue: new MetricValue(1100000, "GBP"));
+            
+            //    Details of the new portfolio to be created, created here with the minimum set of mandatory fields 
+            var createPortfolioRequest = new CreateTransactionPortfolioRequest(
+                code: $"id-{uuid}",
+                displayName: $"Portfolio-{uuid}",
+                baseCurrency: "GBP",
+                created: effectiveDate,
+                
+                //    Set the property value when creating the portfolio
+                properties: new Dictionary<string, Property>
+                {
+                    [metricPropertyDefinitionResult.Key] = 
+                        new Property(
+                            metricPropertyDefinitionResult.Key, 
+                            metricPropertyValueRequest)
+                }
+            );
+
+            //    Create the portfolio
+            var portfolioResult = _apiFactory.Api<ITransactionPortfoliosApi>().CreatePortfolio(TestDataUtilities.TutorialScope, createPortfolioRequest);
+            
+            Assert.That(portfolioResult.Id.Code, Is.EqualTo(createPortfolioRequest.Code));
+
+            var portfolioProperties = _apiFactory.Api<IPortfoliosApi>().GetPortfolioProperties(TestDataUtilities.TutorialScope, portfolioResult.Id.Code).Properties;
+
+            Assert.That(portfolioProperties.Keys, Is.EquivalentTo(new [] { metricPropertyDefinitionResult.Key}));
+
+            // metricProperty.Value is just the value from the metric property, metricProperty.Unit is the units
+            var metricProperty = portfolioProperties[metricPropertyDefinitionResult.Key];
+            Assert.That(metricProperty.Value.MetricValue.Value, Is.EqualTo(metricPropertyValueRequest.MetricValue.Value));
+            Assert.That(metricProperty.Value.MetricValue.Unit, Is.EqualTo(metricPropertyValueRequest.MetricValue.Unit));
+        }
+        
+        [Test]
+        public void Create_Portfolio_With_MultiValue_Property()
+        {
+            var uuid = Guid.NewGuid().ToString();
+            var propertyName = $"managers-{uuid}";
+            var effectiveDate = new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            
+            //    Details of the property to be created
+            var multiValuePropertyDefinition = new CreatePropertyDefinitionRequest(
+                
+                //    The domain the property is to be applied to
+                domain: CreatePropertyDefinitionRequest.DomainEnum.Portfolio,
+                
+                //    The scope the property will be created in
+                scope: TestDataUtilities.TutorialScope,
+                
+                //    When the property value is set it will be valid forever and cannot be changed.
+                //    Properties whose values can change over time should be created with LifeTimeEnum.TIMEVARIANT
+                lifeTime: CreatePropertyDefinitionRequest.LifeTimeEnum.Perpetual,
+                
+                // Multi-value properties have constraint style "Collection"
+                constraintStyle: "Collection",
+                
+                code: propertyName,
+                valueRequired: false,
+                displayName: "Managers",
+                dataTypeId: new ResourceId("system", "string")
+            );
+            
+            //    Create the property definitions
+            var propertyDefinitionResult = _apiFactory.Api<IPropertyDefinitionsApi>().CreatePropertyDefinition(multiValuePropertyDefinition);
+            
+            //    Create the property values
+            var propertyValue = CreateLabelSet("PortfolioManager1","PortfolioManager2");
+            
+            //    Details of the new portfolio to be created, created here with the minimum set of mandatory fields 
+            var createPortfolioRequest = new CreateTransactionPortfolioRequest(
+                code: $"id-{uuid}",
+                displayName: $"Portfolio-{uuid}",
+                baseCurrency: "GBP",
+                created: effectiveDate
+            );
+
+            //    Create the portfolio
+            var portfolioResult = _apiFactory.Api<ITransactionPortfoliosApi>().CreatePortfolio(TestDataUtilities.TutorialScope, createPortfolioRequest);
+            
+            Assert.That(portfolioResult.Id.Code, Is.EqualTo(createPortfolioRequest.Code));
+            
+            var propertiesUpsertResult = _apiFactory.Api<IPortfoliosApi>().UpsertPortfolioProperties(
+                TestDataUtilities.TutorialScope,
+                portfolioResult.Id.Code,
+                new Dictionary<string, Property>
+                {
+                    [propertyDefinitionResult.Key] = 
+                        new Property(
+                            propertyDefinitionResult.Key, 
+                            propertyValue)
+                }
+            );
+            Assert.That(propertiesUpsertResult.Properties.Values.Single().Value.LabelValueSet, Is.EqualTo(propertyValue.LabelValueSet));
+
+            var portfolioProperties = _apiFactory.Api<IPortfoliosApi>().GetPortfolioProperties(TestDataUtilities.TutorialScope, portfolioResult.Id.Code).Properties;
+
+            Assert.That(portfolioProperties.Keys, Is.EquivalentTo(new [] { propertyDefinitionResult.Key}));
+
+            var returnedProperty = portfolioProperties[propertyDefinitionResult.Key];
+            Assert.That(returnedProperty.Value, Is.EqualTo(propertyValue).Using(Comparer));
+        }
+    }
+}

--- a/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
+++ b/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
@@ -39,7 +39,8 @@ namespace Lusid.Sdk.Utilities
             return new PropertyValue(labelValueSet: new LabelValueSet(values.ToList()));
         }
         
-        public static PropertyComparer Comparer => new PropertyComparer(); 
+        public static PropertyComparer PropertyEquality => new PropertyComparer();
+        public static LabelValueSetComparer LabelValueSetEquality => new LabelValueSetComparer();
 
         /// <summary>
         /// Compares LabelSetValues without ordering, unlike the default SDK behaviour.
@@ -48,28 +49,41 @@ namespace Lusid.Sdk.Utilities
         {
             public int Compare(Property p1, Property p2)
             {
-                return Equals(p1, p2, CompareNonNull) ? 0 : 1;
+                return AreEqual(p1, p2, CompareNonNull) ? 0 : 1;
             }
             
-            private bool CompareNonNull(Property p1, Property p2)
+            private static bool CompareNonNull(Property p1, Property p2)
             {
                 return Equals(p1.Key, p2.Key) &&
                        Equals(p1.Value.LabelValue, p2.Value.LabelValue) &&
                        Equals(p1.Value.MetricValue, p2.Value.MetricValue) &&
-                       Equals(p1.Value.LabelValueSet, p2.Value.LabelValueSet,
-                           (a,b) => a.Values.OrderBy(e => e).SequenceEqual(b.Values.OrderBy(e => e)));
+                       AreEqual(p1.Value.LabelValueSet, p2.Value.LabelValueSet, LabelValueSetComparer.CompareNonNull);
             }
-            
-            private bool Equals<T>(T a, T b, Func<T,T,bool> nonNullEquals)
-            {
-                if (ReferenceEquals(a, null) && ReferenceEquals(b, null))
-                    return true;
-                
-                if (ReferenceEquals(a, null) || ReferenceEquals(b, null))
-                    return false;
+        }
 
-                return nonNullEquals(a, b);
+        public class LabelValueSetComparer : IComparer<LabelValueSet>
+        {
+            public int Compare(LabelValueSet l1, LabelValueSet l2)
+            {
+                return AreEqual(l1, l2, CompareNonNull) ? 0 : 1;
             }
+
+            internal static bool CompareNonNull(LabelValueSet l1, LabelValueSet l2)
+            {
+                return l1.Values.OrderBy(e => e)
+                    .SequenceEqual(l2.Values.OrderBy(e => e));
+            }
+        }
+        
+        private static bool AreEqual<T>(T a, T b, Func<T,T,bool> nonNullEquals)
+        {
+            if (ReferenceEquals(a, null) && ReferenceEquals(b, null))
+                return true;
+                
+            if (ReferenceEquals(a, null) || ReferenceEquals(b, null))
+                return false;
+
+            return nonNullEquals(a, b);
         }
     }
 }

--- a/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
+++ b/sdk/Lusid.Sdk/Utilities/PropertyExtensions.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Lusid.Sdk.Model;
+
+namespace Lusid.Sdk.Utilities
+{
+    /// <summary>
+    /// Utilities for working with Properties.
+    /// </summary>
+    internal static class PropertyExtensions
+    {
+        /// <summary>
+        /// Creates a PropertyValue containing a string label.
+        /// </summary>
+        public static PropertyValue CreateLabel(string value)
+        {
+            return new PropertyValue(labelValue: value);
+        }
+
+        /// <summary>
+        /// Creates a PropertyValue containing a metric value with unit.
+        /// </summary>
+        public static PropertyValue CreateMetric(decimal value, string unit)
+        {
+            return new PropertyValue(metricValue: new MetricValue(value, unit));
+        }
+        
+        /// <summary>
+        /// Creates a PropertyValue containing a set of distinct string labels.
+        /// </summary>
+        public static PropertyValue CreateLabelSet(params string[] values)
+        {
+            if (values.Distinct().Count() != values.Length)
+            {
+                throw new ArgumentException("Labels must be distinct.", nameof(values));
+            }
+            
+            return new PropertyValue(labelValueSet: new LabelValueSet(values.ToList()));
+        }
+        
+        public static PropertyComparer Comparer => new PropertyComparer(); 
+
+        /// <summary>
+        /// Compares LabelSetValues without ordering, unlike the default SDK behaviour.
+        /// </summary>
+        public class PropertyComparer : IComparer<Property>
+        {
+            public int Compare(Property p1, Property p2)
+            {
+                return Equals(p1, p2, CompareNonNull) ? 0 : 1;
+            }
+            
+            private bool CompareNonNull(Property p1, Property p2)
+            {
+                return Equals(p1.Key, p2.Key) &&
+                       Equals(p1.Value.LabelValue, p2.Value.LabelValue) &&
+                       Equals(p1.Value.MetricValue, p2.Value.MetricValue) &&
+                       Equals(p1.Value.LabelValueSet, p2.Value.LabelValueSet,
+                           (a,b) => a.Values.OrderBy(e => e).SequenceEqual(b.Values.OrderBy(e => e)));
+            }
+            
+            private bool Equals<T>(T a, T b, Func<T,T,bool> nonNullEquals)
+            {
+                if (ReferenceEquals(a, null) && ReferenceEquals(b, null))
+                    return true;
+                
+                if (ReferenceEquals(a, null) || ReferenceEquals(b, null))
+                    return false;
+
+                return nonNullEquals(a, b);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Properties now support multiple label values at a given effective time. Previously the value could be a single label or metric.

Initially multi-value properties are supported on portfolios only.

The corresponding Property Definition must have a ConstraintStyle of "Collection". Add multiple values using a PropertyValue containing a LabelValueSet.