### PR TITLE
SE-400 Updated the refresh token logic so that even if both the acces…

### DIFF
--- a/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
+++ b/sdk/Lusid.Sdk.Tests/TokenProviderTests.cs
@@ -101,5 +101,32 @@ namespace Lusid.Sdk.Tests
             var __ = config.AccessToken;
             mockTokenProvider.Verify(x => x.GetAuthenticationTokenAsync(), Times.Exactly(2));
         }
+        
+        [Test]
+        public async Task CanGetNewTokenWhenRefreshTokenExpired()
+        {
+            
+            var provider = new ClientCredentialsFlowTokenProvider(GetConfig());
+            var _ = await provider.GetAuthenticationTokenAsync();
+            var firstTokenDetails = provider.GetLastToken();
+
+            Assert.That(firstTokenDetails.RefreshToken, Is.Not.Null.And.Not.Empty, "refresh_token not returned so unable to verify refresh behaviour.");
+
+            Console.WriteLine($"Token expiring at {firstTokenDetails.ExpiresOn:o}");
+
+            // WHEN we pretend to delay until both...
+            // (1) the original token has expired (for expediency update the expires_on on the token)
+            provider.ExpireToken();
+            // (2) the refresh token has expired (for expediency update the refresh_token to an invalid value that will not be found)
+            provider.ExpireRefreshToken();
+
+            Assert.That(DateTimeOffset.UtcNow, Is.GreaterThan(firstTokenDetails.ExpiresOn));
+            var refreshedToken = await provider.GetAuthenticationTokenAsync();
+
+            // THEN it should be populated, and the ExpiresOn should be in the future
+            Assert.That(refreshedToken, Is.Not.Empty);
+            Assert.That(provider.GetLastToken().ExpiresOn, Is.GreaterThan(DateTimeOffset.UtcNow));
+        }
+
     }
 }


### PR DESCRIPTION
…s token and refresh token are expired a new access token can be generated from Okta

# Pull Request Checklist

- [ ] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
