### PR TITLE
PLAT-375: Add delay for ListPortfoliosForScope

### DIFF
--- a/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Portfolios.cs
+++ b/sdk/Lusid.Sdk.Tests/tutorials/Ibor/Portfolios.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Lusid.Sdk.Api;
 using Lusid.Sdk.Model;
 using Lusid.Sdk.Tests.Utilities;
@@ -255,6 +256,9 @@ namespace Lusid.Sdk.Tests.Tutorials.Ibor
             {
                 _testDataUtilities.CreateTransactionPortfolio(scope);
             }
+            
+            //    Wait for the scope of the portfolio to be indexed and for the portfolio to be retrievable
+            Thread.Sleep(2000);
             
             //    Retrieve the list of portfolios from a given scope           
             var portfolios = _apiFactory.Api<IPortfoliosApi>().ListPortfoliosForScope(scope);


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR
Adds a delay after creating portfolios to allow the portfolios to be listed when ListPortfoliosForScope is invoked.
