### PR TITLE
CTECH-821: Fix utc times on cut labels

### DIFF
--- a/sdk/Lusid.Sdk.Tests/Utilities/DateTimeOrCutLabelTests.cs
+++ b/sdk/Lusid.Sdk.Tests/Utilities/DateTimeOrCutLabelTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Lusid.Sdk.Tests.Utilities
@@ -72,6 +73,25 @@ namespace Lusid.Sdk.Tests.Utilities
 
             Assert.That(c, Is.Not.SameAs(d));
             Assert.That(c, Is.EqualTo(d));
+        }
+
+        class JsonCutLabel
+        {
+            public JsonCutLabel()
+            {
+            }
+
+            public DateTimeOrCutLabel dt { get; set; }
+        }
+
+        [TestCase("{'dt': '2021-10-29T00:00:00.0000000+00:00'}")]
+        [TestCase("{'dt': '2021-10-29T01:00:00.0000000+01:00'}")]
+        [TestCase("{'dt': '2021-10-29T00:00:00.0000000Z'}")]
+        public void Deserialize_CutLabelJsonConverter(string json)
+        {
+            var jcl = JsonConvert.DeserializeObject<JsonCutLabel>(json, converters: new JsonConverter[] { new CutLabelJsonConverter() });
+
+            Assert.That(jcl.dt.Parameter, Is.EqualTo("2021-10-29T00:00:00.0000000+00:00"));
         }
     }
 }

--- a/sdk/Lusid.Sdk/Utilities/DateTimeOrCutLabel.cs
+++ b/sdk/Lusid.Sdk/Utilities/DateTimeOrCutLabel.cs
@@ -106,7 +106,7 @@ namespace Lusid.Sdk
             switch (o)
             {
                 case DateTime dt:
-                    return new DateTimeOrCutLabel(dt);
+                    return new DateTimeOrCutLabel(dt.ToUniversalTime());
 
                 case DateTimeOffset dto:
                     return new DateTimeOrCutLabel(dto);


### PR DESCRIPTION
# Pull Request Checklist

- [x] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Fixed daylight savings bug when retrieving dates via CutLabels
